### PR TITLE
variable default values

### DIFF
--- a/index.js
+++ b/index.js
@@ -96,7 +96,7 @@ function extendFile(file, options ,afterExtend) {
         return
     }
 
-    var masterAbsolute 
+    var masterAbsolute
     if(options.root && isRelativeToRoot(masterRelativePath)){
         masterAbsolute = path.join(process.cwd(), options.root, masterRelativePath)
     }else{
@@ -198,10 +198,13 @@ function findPlaceholder(string) {
 function interpolateVariables(template, context) {
     if (!context) { return template }
     if (template.indexOf('@@var') < 0) { return template }
-    var regex = /<!--\s*@@var\s*[= ]\s*(\S+?)\s*-->/
+    var regex = /<!--\s*@@var\s*[= ]\s*(\S+?)\s*(?:"([^"\\]*(?:\\.[^"\\]*)*)"\s*)?-->/
     var match = regex.exec(template)
     while (match) {
-        template = template.replace(match[0], context[match[1]] || '')
+        if (match[2] !== undefined) {
+          match[2] = match[2].replace(/\\"/g, '"');
+        }
+        template = template.replace(match[0], context[match[1]] || match[2] || '')
         match = regex.exec(template)
     }
     return template

--- a/test/expected/absolute_path.html
+++ b/test/expected/absolute_path.html
@@ -5,6 +5,7 @@
         <title>var in master_b.html</title>
 <!-- start include.html-->
 included content
+987654321"
 <!-- start include_include.html-->
 included * 2
 
@@ -22,6 +23,7 @@ included * 2
     I am extend_and_include.html
 <!-- start include.html-->
 included content123456789
+987654321"
 <!-- start include_include.html-->
 included * 2
 

--- a/test/expected/another.html
+++ b/test/expected/another.html
@@ -5,6 +5,7 @@
         <title>var in master_b.html</title>
 <!-- start include.html-->
 included content
+987654321"
 <!-- start include_include.html-->
 included * 2
 

--- a/test/expected/extend_and_include.html
+++ b/test/expected/extend_and_include.html
@@ -5,6 +5,7 @@
         <title>var in master_b.html</title>
 <!-- start include.html-->
 included content
+987654321"
 <!-- start include_include.html-->
 included * 2
 
@@ -22,6 +23,7 @@ included * 2
     I am extend_and_include.html
 <!-- start include.html-->
 included content123456789
+987654321"
 <!-- start include_include.html-->
 included * 2
 

--- a/test/expected/no_annotations.html
+++ b/test/expected/no_annotations.html
@@ -4,6 +4,7 @@
         <meta charset="UTF-8">
         <title>var in master_b.html</title>
 included content
+987654321"
 included * 2
 
 
@@ -17,6 +18,7 @@ included * 2
 <article>
     I am extend_and_include.html
 included content123456789
+987654321"
 included * 2
 
 

--- a/test/fixtures/include.html
+++ b/test/fixtures/include.html
@@ -1,2 +1,3 @@
 included content<!--@@var=a-->
+<!--@@var=b "987654321\""-->
 <!--@@include= include_include.html-->


### PR DESCRIPTION
Needed this little addition for a recent project.  Extends the regular expression for variable substitution so that you can optionally put a default value in quotes after the variable name.

So `<!-- @@var animal "ocelot" -->` would output "ocelot" unless another value is provided contextually via `@@include` or `@@master`.

Note: I looked at a few different regular expressions, but opted for this one because it captures escaped double-quotes, which are then cleaned up before using the match.